### PR TITLE
feat: Allow roundtrip (de)serialization of magnet links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `MagnetLink` now refuses to parse strings that contain a newline (`\n`), producing
   a `MagnetLinkError::InvalidURINewLine` error
+- `MagnetLink::from_url`, `PeerSource::from_url`, and `Tracker::from_url` now take a
+  `fluent_uri::Uri<String>` instead of a `url::Url` previously
+- all error types with an `InvalidURL` variant now have `fluent_uri::ParseError`
+  as source instead of `url::ParseError` previously
+
+### Added
+
+- `MagnetLink` implements `Display`, so it can be converted to a string again
+  using `MagnetLink::to_string`.
+- `MagnetLink::unsafe_parse_query` allows iterating carefully around magnet link
+  query key/values
+- Added new `MagnetLinkError` variants to be more precise about what's wrong with
+  a parsed magnet link.
 
 ## Version 0.3.2 (2025-08-29)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ sha1 = "0.10"
 sha256 = "1.5"
 rustc-hex = "2.1"
 serde = { version = "1", features = [ "derive" ] }
-url = "2.5"
+fluent-uri = { git = "https://github.com/yescallop/fluent-uri-rs", rev = "5ad3b65" }
 
 [dev-dependencies]
 serde_json = "1"


### PR DESCRIPTION
Before we can properly parse trackers and edit torrents/magnets, make sure that a magnet link that has been parsed can be reserialized to the same magnet link.

This PR also introduces breaking changes and other additions described in README.md