### PR TITLE
deps: Update to fluent_uri v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ sha1 = "0.10"
 sha256 = "1.5"
 rustc-hex = "2.1"
 serde = { version = "1", features = [ "derive" ] }
-fluent-uri = { git = "https://github.com/yescallop/fluent-uri-rs", rev = "5ad3b65", features = [ "serde" ] }
+fluent-uri = "0.4"
 
 [dev-dependencies]
 serde_json = "1"


### PR DESCRIPTION
Now that the changes have been released (and some more), fall back to release v0.4

The reason for using the development branch was that some structs implemented PartialEq/Clone/Debug which is useful.

See https://github.com/yescallop/fluent-uri-rs/issues/40